### PR TITLE
Updated key vault to use private endpoint

### DIFF
--- a/infra/tf/.gitignore
+++ b/infra/tf/.gitignore
@@ -5,7 +5,5 @@
 crash.log
 *.backup
 *.log
-*.tfvars
 *tfplan
 *.plan
-!local.terraform.tfvars

--- a/infra/tf/main.tf
+++ b/infra/tf/main.tf
@@ -64,6 +64,8 @@ module "key_vault" {
   purge_protection_enabled  = var.key_vault_purge_protection_enabled
   soft_delete_retention_days = var.key_vault_soft_delete_retention_days
   log_analytics_workspace_id = module.log_analytics.workspace_id
+  vnet_id                   = module.vnet.vnet_id
+  subnet_id                 = module.vnet.subnet_ids["private-endpoints"]
 }
 
 module "api_management" {

--- a/infra/tf/modules/key_vault/main.tf
+++ b/infra/tf/modules/key_vault/main.tf
@@ -23,3 +23,25 @@ resource "azurerm_monitor_diagnostic_setting" "kv_diag" {
     category = "AllMetrics"
   }
 }
+
+module "private_dns_zone" {
+  source              = "../private_dns_zone"
+  zone_name           = "privatelink.vaultcore.azure.net"
+  resource_group_name = var.resource_group_name
+  link_name           = "kv-dns-link"
+  vnet_id             = var.vnet_id
+  create_a_record     = true
+  a_record_name       = var.key_vault_name
+  a_record_ip         = module.private_endpoint.private_ip_address
+}
+
+module "private_endpoint" {
+  source                        = "../private_endpoint"
+  name                          = "${var.key_vault_name}-pe"
+  location                      = var.location
+  resource_group_name           = var.resource_group_name
+  subnet_id                     = var.subnet_id
+  connection_name               = "${var.key_vault_name}-pe-conn"
+  private_connection_resource_id = azurerm_key_vault.this.id
+  subresource_names             = ["vault"]
+}

--- a/infra/tf/modules/key_vault/outputs.tf
+++ b/infra/tf/modules/key_vault/outputs.tf
@@ -5,3 +5,11 @@ output "key_vault_id" {
 output "key_vault_name" {
   value = azurerm_key_vault.this.name
 }
+
+output "private_endpoint_ip" {
+  value = module.private_endpoint.private_ip_address
+}
+
+output "private_dns_zone_name" {
+  value = module.private_dns_zone.zone_name
+}

--- a/infra/tf/modules/key_vault/variables.tf
+++ b/infra/tf/modules/key_vault/variables.tf
@@ -40,3 +40,13 @@ variable "soft_delete_retention_days" {
   type        = number
   default     = 7
 }
+
+variable "vnet_id" {
+  description = "The ID of the Virtual Network to link the DNS zone and for the private endpoint."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "The subnet ID for the Key Vault private endpoint."
+  type        = string
+}

--- a/infra/tf/modules/private_dns_zone/main.tf
+++ b/infra/tf/modules/private_dns_zone/main.tf
@@ -1,0 +1,26 @@
+# Reusable Private DNS Zone Module
+resource "azurerm_private_dns_zone" "this" {
+  name                = var.zone_name
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "this" {
+  name                  = var.link_name
+  resource_group_name   = var.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.this.name
+  virtual_network_id    = var.vnet_id
+  registration_enabled  = false
+}
+
+resource "azurerm_private_dns_a_record" "this" {
+  count               = var.create_a_record ? 1 : 0
+  name                = var.a_record_name
+  zone_name           = azurerm_private_dns_zone.this.name
+  resource_group_name = var.resource_group_name
+  ttl                 = 300
+  records             = [var.a_record_ip]
+}
+
+output "zone_name" {
+  value = azurerm_private_dns_zone.this.name
+}

--- a/infra/tf/modules/private_dns_zone/variables.tf
+++ b/infra/tf/modules/private_dns_zone/variables.tf
@@ -1,0 +1,7 @@
+variable "zone_name" { type = string }
+variable "resource_group_name" { type = string }
+variable "link_name" { type = string }
+variable "vnet_id" { type = string }
+variable "create_a_record" { type = bool }
+variable "a_record_name" { type = string }
+variable "a_record_ip" { type = string }

--- a/infra/tf/modules/private_endpoint/main.tf
+++ b/infra/tf/modules/private_endpoint/main.tf
@@ -1,0 +1,18 @@
+# Reusable Private Endpoint Module
+resource "azurerm_private_endpoint" "this" {
+  name                = var.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.subnet_id
+
+  private_service_connection {
+    name                           = var.connection_name
+    private_connection_resource_id = var.private_connection_resource_id
+    subresource_names              = var.subresource_names
+    is_manual_connection           = false
+  }
+}
+
+output "private_ip_address" {
+  value = azurerm_private_endpoint.this.private_service_connection[0].private_ip_address
+}

--- a/infra/tf/modules/private_endpoint/variables.tf
+++ b/infra/tf/modules/private_endpoint/variables.tf
@@ -1,0 +1,7 @@
+variable "name" { type = string }
+variable "location" { type = string }
+variable "resource_group_name" { type = string }
+variable "subnet_id" { type = string }
+variable "connection_name" { type = string }
+variable "private_connection_resource_id" { type = string }
+variable "subresource_names" { type = list(string) }

--- a/infra/tf/terraform.tfvars
+++ b/infra/tf/terraform.tfvars
@@ -1,0 +1,152 @@
+resource_group_name = "RG-AIS-LZ-TF"
+location            = "eastus2"
+subscription_id = "c5d4a6e8-69bf-4148-be25-cb362f83c370"
+suffix       = "lz-tf"
+environment  = "dev"
+
+vnet_address_spaces = [
+  "10.10.0.0/16"
+]
+
+vnet_subnets = [
+  {
+    name             = "ase"
+    address_prefixes = ["10.10.1.0/24"]
+    route_table      = null
+    delegation = {
+      name         = "ase-delegation"
+      service_name = "Microsoft.Web/hostingEnvironments"
+      actions      = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+    service_endpoints = []
+  },
+  {
+    name             = "private-endpoints"
+    address_prefixes = ["10.10.2.0/24"]
+    nsg              = null
+    route_table      = null
+    delegation       = null
+    service_endpoints = []
+  },
+  {
+    name             = "apim"
+    address_prefixes = ["10.10.3.0/24"]
+    nsg = {
+      name           = "apim-nsg"
+      security_rules = [
+        // Inbound rules
+        {
+          name                         = "AllowApimManagementInbound"
+          priority                     = 100
+          direction                    = "Inbound"
+          access                       = "Allow"
+          protocol                     = "Tcp"
+          source_port_range            = "*"
+          destination_port_range       = "3443"
+          source_address_prefix        = "ApiManagement"
+          destination_address_prefix   = "VirtualNetwork"
+          description                  = "Allow inbound management traffic from Azure API Management service on port 3443"
+        },
+        {
+          name                         = "AllowAzureLoadBalancerInBound"
+          priority                     = 200
+          direction                    = "Inbound"
+          access                       = "Allow"
+          protocol                     = "Tcp"
+          source_port_range            = "*"
+          destination_port_range       = "6390"
+          source_address_prefix        = "AzureLoadBalancer"
+          destination_address_prefix   = "VirtualNetwork"
+          description                  = "Allow inbound health probe traffic from Azure Load Balancer on port 6390"
+        },
+        {
+          name                         = "AzureTrafficManagerInbound"
+          priority                     = 300
+          direction                    = "Inbound"
+          access                       = "Allow"
+          protocol                     = "Tcp"
+          source_port_range            = "*"
+          destination_port_range       = "443"
+          source_address_prefix        = "AzureTrafficManager"
+          destination_address_prefix   = "Virtualnetwork"
+          description                  = "Allow inbound traffic from Azure Traffic Manager on port 443"
+        },
+        // Outbound rules
+        {
+          name                         = "AllowStorageOutbound"
+          priority                     = 400
+          direction                    = "Outbound"
+          access                       = "Allow"
+          protocol                     = "Tcp"
+          source_port_range            = "*"
+          destination_port_range       = "443"
+          source_address_prefix        = "VirtualNetwork"
+          destination_address_prefix   = "Storage"
+          description                  = "Allow outbound traffic to Azure Storage on port 443"
+        },
+        {
+          name                         = "AllowSqlOutbound"
+          priority                     = 500
+          direction                    = "Outbound"
+          access                       = "Allow"
+          protocol                     = "Tcp"
+          source_port_range            = "*"
+          destination_port_range       = "1433"
+          source_address_prefix        = "VirtualNetwork"
+          destination_address_prefix   = "SQL"
+          description                  = "Allow outbound traffic to Azure SQL Database on port 1433"
+        },
+        {
+          name                         = "AllowAzureKeyVaultOutbound"
+          priority                     = 600
+          direction                    = "Outbound"
+          access                       = "Allow"
+          protocol                     = "Tcp"
+          source_port_range            = "*"
+          destination_port_range       = "443"
+          source_address_prefix        = "VirtualNetwork"
+          destination_address_prefix   = "AzureKeyVault"
+          description                  = "Allow outbound traffic to Azure Key Vault on port 443"
+        },
+        {
+          name                       = "AllowAzureMonitorOutbound1886"
+          priority                   = 700
+          direction                  = "Outbound"
+          access                     = "Allow"
+          protocol                   = "Tcp"
+          source_port_range          = "*"
+          destination_port_range     = "1886"
+          source_address_prefix      = "VirtualNetwork"
+          destination_address_prefix = "AzureMonitor"
+          description                = "Allow outbound traffic to Azure Monitor on port 1886"
+        },
+        {
+          name                       = "AllowAzureMonitorOutbound443"
+          priority                   = 800
+          direction                  = "Outbound"
+          access                     = "Allow"
+          protocol                   = "Tcp"
+          source_port_range          = "*"
+          destination_port_range     = "443"
+          source_address_prefix      = "VirtualNetwork"
+          destination_address_prefix = "AzureMonitor"
+          description                = "Allow outbound traffic to Azure Monitor on port 443"
+        }
+      ]
+      diag_enabled = true
+    }
+    route_table      = null
+    delegation       = null
+    service_endpoints = []
+  }
+]
+
+key_vault_purge_protection_enabled = true
+key_vault_soft_delete_retention_days = 7
+
+apim_publisher_name  = "Contoso"
+apim_publisher_email = "apis@contoso.net"
+apim_sku_name     = "Developer"
+apim_sku_capacity = 1
+
+deploy_api_management = true


### PR DESCRIPTION
This pull request introduces significant updates to the Terraform configuration for setting up Azure Key Vault with private networking. The changes include integrating private endpoints, private DNS zones, and corresponding outputs and variables to enhance security and connectivity. Below is a summary of the most important changes:

### Key Vault Private Networking Enhancements:
* Added support for specifying `vnet_id` and `subnet_id` in the `key_vault` module to enable private endpoint and DNS zone integration (`infra/tf/main.tf`).
* Introduced modules for creating private endpoints and private DNS zones, including configurations for linking the DNS zone to a virtual network and creating DNS A records (`infra/tf/modules/key_vault/main.tf`).

### Outputs for Private Networking:
* Added new outputs to the `key_vault` module to expose the private endpoint IP address and private DNS zone name for downstream usage (`infra/tf/modules/key_vault/outputs.tf`).

### New Reusable Modules:
* Created a reusable `private_dns_zone` module to manage private DNS zones, virtual network links, and optional A records (`infra/tf/modules/private_dns_zone/main.tf`, `infra/tf/modules/private_dns_zone/variables.tf`). [[1]](diffhunk://#diff-afbba182b2aef3d9c8417a992ad5a4de6c20bf927f5154e83c0b660034b23601R1-R26) [[2]](diffhunk://#diff-d8c312d7db2bfd514f9c06f2371b8f76f0e64e28c05e225153de394f4421c325R1-R7)
* Created a reusable `private_endpoint` module to manage private endpoints with support for service connections (`infra/tf/modules/private_endpoint/main.tf`, `infra/tf/modules/private_endpoint/variables.tf`). [[1]](diffhunk://#diff-d9204b2b0484bbdaf4a25c76cf7f4fb00eaadc6ef988ef80ea6a3ecf9d6321b4R1-R18) [[2]](diffhunk://#diff-6ca453f3dd27ebe64d98809796805bad382bae320d01c01c74b7ebeda6a5a75fR1-R7)

### New Variables:
* Added variables `vnet_id` and `subnet_id` to the `key_vault` module for configuring private networking (`infra/tf/modules/key_vault/variables.tf`).