### PR TITLE
fixed copilots errors on the dev env setup workflow

### DIFF
--- a/.github/workflows/copilot-setup.yml
+++ b/.github/workflows/copilot-setup.yml
@@ -1,4 +1,4 @@
-name: Copilot Coding Agent Setup
+name: Copilot Setup Steps
 
 on:
   # This workflow is triggered when the Copilot Coding Agent is initialized
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  setup:
+  copilot-setup-steps:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -18,11 +18,6 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: latest
-
-      - name: Install Azure CLI
-        run: |
-          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-          az --version
 
       - name: Set Azure environment variables
         env:
@@ -37,3 +32,17 @@ jobs:
           echo "AZURE_TENANT_ID=${{ secrets.AZURE_TENANT_ID }}" >> $GITHUB_ENV
           echo "AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION_ID }}" >> $GITHUB_ENV
           # Environment variables will be available to the Copilot agent via the GitHub Actions environment
+      
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          auth-type: SERVICE_PRINCIPAL
+      
+      - name: 'az-group-list'
+        run: |
+          az group list --output table
+          # This command lists all Azure resource groups in the subscription.
+          # It can be useful for the Copilot Coding Agent to understand the existing infrastructure.


### PR DESCRIPTION
This pull request updates the `.github/workflows/copilot-setup.yml` file to rename the workflow, restructure job names, and modify Azure-related setup steps. The changes simplify the workflow while adding functionality for Azure authentication and resource group listing.

### Workflow restructuring:

* Renamed the workflow from `Copilot Coding Agent Setup` to `Copilot Setup Steps` for clarity.
* Renamed the job `setup` to `copilot-setup-steps` to better reflect its purpose.

### Azure-related modifications:

* Removed the manual installation of the Azure CLI to streamline the workflow.
* Added an `Azure Login` step using the `azure/login@v1` GitHub Action for authentication with Azure via a service principal.
* Added a new step, `az-group-list`, to list Azure resource groups in the subscription, aiding the Copilot agent in understanding the infrastructure.