### PR TITLE
added permission for id token

### DIFF
--- a/.github/workflows/copilot-setup.yml
+++ b/.github/workflows/copilot-setup.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-
+  id-token: write
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change adds the `id-token: write` permission to the workflow.

* [`.github/workflows/copilot-setup.yml`](diffhunk://#diff-50d98051b55012758382e4ef9a3803ec984856e2a6809d1581fe1a1060638c81L9-R9): Added `id-token: write` under the `permissions` section to enable workflows to authenticate with GitHub's OIDC provider.